### PR TITLE
Phase 1: add C2 sync jobs schema foundation

### DIFF
--- a/db/migrations/20260616192213_create_c2_sync_jobs.sql
+++ b/db/migrations/20260616192213_create_c2_sync_jobs.sql
@@ -1,0 +1,65 @@
+-- Phase 1 durable state for docs/c2-background-sync-plan.md.
+CREATE TABLE IF NOT EXISTS public.c2_sync_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  status text NOT NULL DEFAULT 'queued' CHECK (
+    status IN (
+      'queued',
+      'running',
+      'completed',
+      'failed',
+      'partial_success',
+      'cancelled'
+    )
+  ),
+  range text NOT NULL,
+  options jsonb NOT NULL DEFAULT '{}'::jsonb,
+  current_page integer CHECK (current_page IS NULL OR current_page >= 0),
+  total_pages integer CHECK (total_pages IS NULL OR total_pages >= 0),
+  total_workouts integer CHECK (total_workouts IS NULL OR total_workouts >= 0),
+  processed_count integer NOT NULL DEFAULT 0 CHECK (processed_count >= 0),
+  saved_count integer NOT NULL DEFAULT 0 CHECK (saved_count >= 0),
+  skipped_count integer NOT NULL DEFAULT 0 CHECK (skipped_count >= 0),
+  failed_count integer NOT NULL DEFAULT 0 CHECK (failed_count >= 0),
+  last_error text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_c2_sync_jobs_user_created
+  ON public.c2_sync_jobs (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_c2_sync_jobs_user_status
+  ON public.c2_sync_jobs (user_id, status, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.update_c2_sync_jobs_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_c2_sync_jobs_updated_at ON public.c2_sync_jobs;
+CREATE TRIGGER trg_c2_sync_jobs_updated_at
+  BEFORE UPDATE ON public.c2_sync_jobs
+  FOR EACH ROW EXECUTE FUNCTION public.update_c2_sync_jobs_updated_at();
+
+ALTER TABLE public.c2_sync_jobs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view their own C2 sync jobs" ON public.c2_sync_jobs;
+CREATE POLICY "Users can view their own C2 sync jobs"
+  ON public.c2_sync_jobs
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Service role can manage C2 sync jobs" ON public.c2_sync_jobs;
+CREATE POLICY "Service role can manage C2 sync jobs"
+  ON public.c2_sync_jobs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);

--- a/docs/c2-background-sync-plan.md
+++ b/docs/c2-background-sync-plan.md
@@ -144,6 +144,8 @@ Deliverables:
 - Add generated TypeScript types.
 - Add a minimal UI/service read path for job status if needed.
 
+Implementation note: this phase is represented by the `c2_sync_jobs` schema and the minimal latest-job read helper only. It intentionally does not start background sync jobs, run C2 batch work, or alter the existing browser `useConcept2Sync` path.
+
 Done when:
 
 - A logged-in user can see only their own sync jobs.

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,5 +1,6 @@
 
 import { createClient } from '@supabase/supabase-js'
+import type { Tables } from '../types/database.types'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -111,6 +112,31 @@ export interface WorkoutTemplate {
     usage_count?: number;
 }
 
+export type C2SyncJobStatus =
+    | 'queued'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'partial_success'
+    | 'cancelled'
+
+export type C2SyncJob = Tables<'c2_sync_jobs'> & {
+    status: C2SyncJobStatus
+}
+
+export const getLatestC2SyncJob = async (userId: string): Promise<C2SyncJob | null> => {
+    const { data, error } = await supabase
+        .from('c2_sync_jobs')
+        .select('*')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+    if (error) throw error
+    return data as C2SyncJob | null
+}
+
 export const upsertWorkout = async (workout: Partial<WorkoutLog>) => {
     // We use external_id as the unique key to prevent duplicates
     const { data, error } = await supabase
@@ -159,4 +185,3 @@ export const getWorkoutTemplates = async () => {
     }
     return data as WorkoutTemplate[];
 };
-

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -497,6 +497,66 @@ export type Database = {
         }
         Relationships: []
       }
+      c2_sync_jobs: {
+        Row: {
+          created_at: string
+          current_page: number | null
+          failed_count: number
+          finished_at: string | null
+          id: string
+          last_error: string | null
+          options: Json
+          processed_count: number
+          range: string
+          saved_count: number
+          skipped_count: number
+          started_at: string | null
+          status: string
+          total_pages: number | null
+          total_workouts: number | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          current_page?: number | null
+          failed_count?: number
+          finished_at?: string | null
+          id?: string
+          last_error?: string | null
+          options?: Json
+          processed_count?: number
+          range: string
+          saved_count?: number
+          skipped_count?: number
+          started_at?: string | null
+          status?: string
+          total_pages?: number | null
+          total_workouts?: number | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          current_page?: number | null
+          failed_count?: number
+          finished_at?: string | null
+          id?: string
+          last_error?: string | null
+          options?: Json
+          processed_count?: number
+          range?: string
+          saved_count?: number
+          skipped_count?: number
+          started_at?: string | null
+          status?: string
+          total_pages?: number | null
+          total_workouts?: number | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       coaching_access_requests: {
         Row: {
           created_at: string


### PR DESCRIPTION
## Summary
- add the c2_sync_jobs Supabase migration with status/progress fields, indexes, updated_at trigger, and RLS policies
- add generated Supabase types for c2_sync_jobs
- add a read-only getLatestC2SyncJob helper and document the Phase 1 boundary

## Verification
- npm run build
- npm run lint
- npm run test:run
- Supabase MCP apply_migration: create_c2_sync_jobs, ledger version 20260616194437
- Spark drift report: aligned

Refs #37