### PR TITLE
ci: add Spark PR readiness check

### DIFF
--- a/.github/workflows/spark-pr-readiness.yml
+++ b/.github/workflows/spark-pr-readiness.yml
@@ -1,0 +1,24 @@
+name: Spark PR Readiness
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  spark-pr-readiness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm --prefix packages/rwn ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run test:run
+      - run: npm --prefix packages/rwn run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@readyall/rwn": "^0.1.0",
         "@supabase/supabase-js": "^2.90.1",
         "@types/react-datepicker": "^6.2.0",
         "autoprefixer": "^10.4.23",
@@ -1630,6 +1631,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@readyall/rwn": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@readyall/rwn/-/rwn-0.1.0.tgz",
+      "integrity": "sha512-3NxnQeAenuJCepSSu4DitQ9EAj7ZHZbxA0FnYl5H4QRIDCP693lV1SJeQnw7HU5TzijpPKwGlK/u6MYyGuwSPA==",
+      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",


### PR DESCRIPTION
## What changed

Adds one pull-request job named spark-pr-readiness using the repository-native build, lint, app test, and RWN package test commands. The root lockfile is synchronized with the declared @readyall/rwn dependency so npm ci is deterministic.

## Why

Spark needs a real repository-owned check before it can treat a published PR as ready for review. The existing lockfile mismatch caused npm ci to fail before validation began.

## Impact

No runtime or product behavior changes. Once this workflow is accepted and protected, Spark can use the exact job result as its PR-readiness contract.

## Verification

- npm ci
- npm --prefix packages/rwn ci
- npm run build
- npm run lint
- npm run test:run (344 tests)
- npm --prefix packages/rwn run test (132 tests)