### PR TITLE
feat: resolve issue #85 - Keep workout comparison dates on their recorded calendar day

### DIFF
--- a/src/pages/WorkoutComparison.test.tsx
+++ b/src/pages/WorkoutComparison.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseLocalDate } from '../utils/dateUtils';
+
+describe('Workout Comparison date displays', () => {
+  it('keeps date-only values on their recorded calendar day in a negative UTC offset', () => {
+    expect(parseLocalDate('2024-01-15').toLocaleDateString('en-US')).toBe('1/15/2024');
+  });
+
+  it('preserves timestamp semantics for ISO date-time values', () => {
+    expect(parseLocalDate('2024-01-15T00:00:00.000Z').toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+});

--- a/src/pages/WorkoutComparison.tsx
+++ b/src/pages/WorkoutComparison.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, SplitSquareHorizontal, Calendar, Zap, Gauge, Trophy, Search,
 import { EmptyState } from '../components/ui';
 import { workoutService } from '../services/workoutService';
 import { formatPace, formatTime } from '../utils/prDetection';
+import { parseLocalDate } from '../utils/dateUtils';
 import { DualWorkoutChart } from '../components/analytics/DualWorkoutChart';
 import type { C2Stroke } from '../api/concept2.types';
 
@@ -152,7 +153,7 @@ const WorkoutSummaryCard = ({ workout, title, onClear }: WorkoutSummaryCardProps
         const paceSeconds = dist > 0 ? (time / dist) * 500 : 0;
         const pace = workout.formatted_pace || formatPace(paceSeconds);
         const watts = workout.watts || (time > 0 && dist > 0 ? Math.round(2.8 / Math.pow((time / dist) * 500 / 500, 3)) : 0);
-        const date = workout.date || workout.completed_at ? new Date(workout.date || workout.completed_at || '').toLocaleDateString() : 'Unknown';
+        const date = workout.date || workout.completed_at ? parseLocalDate(workout.date || workout.completed_at || '').toLocaleDateString() : 'Unknown';
 
         return { dist, pace, watts, date };
     }, [workout]);
@@ -389,7 +390,7 @@ export const WorkoutComparison: React.FC = () => {
                                                 >
                                                     <div className="flex flex-col">
                                                         <span className="text-white font-medium text-sm">{res.name}</span>
-                                                        <span className="text-xs text-neutral-500">{new Date(res.date).toLocaleDateString()}</span>
+                                                        <span className="text-xs text-neutral-500">{parseLocalDate(res.date).toLocaleDateString()}</span>
                                                     </div>
                                                     <div className="flex items-center gap-4">
                                                         <span className="text-xs font-mono text-neutral-400">{res.distance}m</span>
@@ -418,7 +419,7 @@ export const WorkoutComparison: React.FC = () => {
                                                     <div className="text-left">
                                                         <div className="text-sm font-bold text-white">Personal Best</div>
                                                         <div className="text-xs text-neutral-500">
-                                                            {similar.pr.date ? new Date(similar.pr.date).toLocaleDateString() : 'Unknown'} • {similar.pr.watts}w
+                                                            {similar.pr.date ? parseLocalDate(similar.pr.date).toLocaleDateString() : 'Unknown'} • {similar.pr.watts}w
                                                         </div>
                                                     </div>
                                                 </div>
@@ -440,7 +441,7 @@ export const WorkoutComparison: React.FC = () => {
                                                     <div className="text-left">
                                                         <div className="text-sm font-bold text-white">Previous Attempt</div>
                                                         <div className="text-xs text-neutral-500">
-                                                            {similar.previous.date ? new Date(similar.previous.date).toLocaleDateString() : 'Unknown'} • {similar.previous.watts}w
+                                                            {similar.previous.date ? parseLocalDate(similar.previous.date).toLocaleDateString() : 'Unknown'} • {similar.previous.watts}w
                                                         </div>
                                                     </div>
                                                 </div>
@@ -461,7 +462,7 @@ export const WorkoutComparison: React.FC = () => {
                                                     className="w-full flex items-center justify-between p-3 hover:bg-neutral-800 rounded-lg transition-colors text-left"
                                                 >
                                                     <span className="text-sm text-neutral-300">
-                                                        {h.date || h.completed_at ? new Date(h.date || h.completed_at || '').toLocaleDateString() : 'Unknown'}
+                                                        {h.date || h.completed_at ? parseLocalDate(h.date || h.completed_at || '').toLocaleDateString() : 'Unknown'}
                                                     </span>
                                                     <span className="text-sm font-mono text-neutral-500">{h.watts}w</span>
                                                 </button>


### PR DESCRIPTION
## Summary
- Publish validated Spark run wo_logbook-companion_issue_85
- Execution path: validated_without_repair
- Issue satisfaction: satisfied
- Validated changed files: src/pages/WorkoutComparison.test.tsx, src/pages/WorkoutComparison.tsx

## Validation
- final-run-summary.json => publish_ready=true

## Verification Review
- Decision: pass
- Summary: Validation passed and the lightweight verification report found the issue contract satisfied with no blocking concerns.
- Report: verification-report.md

## Spark Metadata
- Spark-Run-Id: wo_logbook-companion_issue_85
- Spark-Branch: spark/wo-logbook-companion-issue-85
- Spark-Satisfaction: satisfied
- Spark-Issue-Number: 85

Closes #85