### PR TITLE
feat: resolve issue #87 - Name the pace overlay correctly in workout comparison

### DIFF
--- a/src/pages/WorkoutComparison.test.tsx
+++ b/src/pages/WorkoutComparison.test.tsx
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseLocalDate } from '../utils/dateUtils';
+import { METRIC_HEADINGS } from './WorkoutComparison';
+
+describe('Workout Comparison metric headings', () => {
+  it.each([
+    ['watts', 'Power Overlay'],
+    ['pace', 'Pace Overlay'],
+    ['rate', 'Stroke Rate'],
+    ['hr', 'Heart Rate'],
+  ] as const)('maps %s to %s', (metric, heading) => {
+    expect(METRIC_HEADINGS[metric]).toBe(heading);
+  });
+});
 
 describe('Workout Comparison date displays', () => {
   it('keeps date-only values on their recorded calendar day in a negative UTC offset', () => {

--- a/src/pages/WorkoutComparison.tsx
+++ b/src/pages/WorkoutComparison.tsx
@@ -64,6 +64,13 @@ interface IntervalComparisonRow {
     splitDelta: string;
 }
 
+export const METRIC_HEADINGS = {
+    watts: 'Power Overlay',
+    pace: 'Pace Overlay',
+    rate: 'Stroke Rate',
+    hr: 'Heart Rate',
+} as const;
+
 const formatSecondsDelta = (deltaSeconds: number | null) => {
     if (deltaSeconds === null || Number.isNaN(deltaSeconds)) return '-';
     if (Math.abs(deltaSeconds) < 0.05) return 'Even';
@@ -489,7 +496,7 @@ export const WorkoutComparison: React.FC = () => {
                                 {chartMetric === 'hr' ? <Heart size={18} className="text-red-500" /> :
                                     chartMetric === 'rate' ? <Activity size={18} className="text-blue-400" /> :
                                         <Zap size={18} className="text-yellow-400" />}
-                                {chartMetric === 'hr' ? 'Heart Rate' : chartMetric === 'rate' ? 'Stroke Rate' : 'Power Overlay'}
+                                {METRIC_HEADINGS[chartMetric]}
                             </h3>
 
                             {/* Metric Toggle */}


### PR DESCRIPTION
## Summary
- Publish validated Spark run wo_logbook-companion_issue_87
- Execution path: validated_without_repair
- Issue satisfaction: satisfied
- Validated changed files: src/pages/WorkoutComparison.test.tsx, src/pages/WorkoutComparison.tsx

## Validation
- final-run-summary.json => publish_ready=true

## Verification Review
- Decision: pass
- Summary: Validation passed and the lightweight verification report found the issue contract satisfied with no blocking concerns.
- Report: verification-report.md

## Spark Metadata
- Spark-Run-Id: wo_logbook-companion_issue_87
- Spark-Branch: spark/wo-logbook-companion-issue-87
- Spark-Satisfaction: satisfied
- Spark-Issue-Number: 87

Closes #87